### PR TITLE
Modified the ResidueResult name attribut

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,10 +49,12 @@ pub struct ResidueResult {
     pub serial_number: isize,
     /// SASA value for residue
     pub value: f32,
-    //// The name of the residue. Format: {Chain ID}_{Name}_{Serial Number}
+    //// The name of the residue
     pub name: String,
     /// Wether the residue is polar
     pub is_polar: bool,
+    /// Chain ID
+    pub chain_id: String,
 }
 
 #[derive(Debug, PartialEq)]
@@ -359,7 +361,8 @@ pub fn calculate_sasa(
                         serial_number: residue.serial_number(),
                         value: sum,
                         is_polar: POLAR_AMINO_ACIDS.contains(&name),
-                        name: format!("{}_{}_{}", chain.id(), name, residue.serial_number()),
+                        chain_id: chain.id().to_string(),
+                        name,
                     })
                 }
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -335,25 +335,27 @@ pub fn calculate_sasa(
         }
         SASALevel::Residue => {
             let mut residue_sasa = vec![];
-            for residue in pdb.residues() {
-                let residue_atom_index = parent_to_atoms
-                    .get(&residue.serial_number())
-                    .context(AtomMapToLevelElementFailedSnafu)?;
-                let residue_atoms: Vec<_> = residue_atom_index
-                    .iter()
-                    .map(|&index| atom_sasa[index])
-                    .collect();
-                let sum = simd_sum(residue_atoms.as_slice());
-                let name = residue
-                    .name()
-                    .context(FailedToGetResidueNameSnafu)?
-                    .to_string();
-                residue_sasa.push(ResidueResult {
-                    serial_number: residue.serial_number(),
-                    value: sum,
-                    is_polar: POLAR_AMINO_ACIDS.contains(&name),
-                    name,
-                })
+            for chain in pdb.chains() {
+                for residue in chain.residues() {
+                    let residue_atom_index = parent_to_atoms
+                        .get(&residue.serial_number())
+                        .context(AtomMapToLevelElementFailedSnafu)?;
+                    let residue_atoms: Vec<_> = residue_atom_index
+                        .iter()
+                        .map(|&index| atom_sasa[index])
+                        .collect();
+                    let sum = simd_sum(residue_atoms.as_slice());
+                    let name = residue
+                        .name()
+                        .context(FailedToGetResidueNameSnafu)?
+                        .to_string();
+                    residue_sasa.push(ResidueResult {
+                        serial_number: residue.serial_number(),
+                        value: sum,
+                        is_polar: POLAR_AMINO_ACIDS.contains(&name),
+                        name: format!("{}-{}-{}", chain.id(), name, residue.serial_number()),
+                    })
+                }
             }
             Ok(SASAResult::Residue(residue_sasa))
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,15 +37,21 @@ pub enum SASALevel {
 
 #[derive(Debug, PartialEq)]
 pub struct ChainResult {
+    /// Chain name
     pub name: String,
+    /// Chain SASA value
     pub value: f32,
 }
 
 #[derive(Debug, PartialEq)]
 pub struct ResidueResult {
+    /// Residue serial number
     pub serial_number: isize,
+    /// SASA value for residue
     pub value: f32,
+    //// The name of the residue. Format: {Chain ID}_{Name}_{Serial Number}
     pub name: String,
+    /// Wether the residue is polar
     pub is_polar: bool,
 }
 
@@ -353,7 +359,7 @@ pub fn calculate_sasa(
                         serial_number: residue.serial_number(),
                         value: sum,
                         is_polar: POLAR_AMINO_ACIDS.contains(&name),
-                        name: format!("{}-{}-{}", chain.id(), name, residue.serial_number()),
+                        name: format!("{}_{}_{}", chain.id(), name, residue.serial_number()),
                     })
                 }
             }


### PR DESCRIPTION
I was working with the `rust-sasa-python` to extract sasa at the residue level and I found that it would be useful to return a vector of tuples with the residue name and the sasa calculated to allow an easy mapping of the residues and their sasa. 

The name of the residues is a combination of chainID-resname-resnum.

Hope this makes sense.

Thanks for sharing this library! 